### PR TITLE
[MINOR] Remove unused guava import

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
+++ b/server/src/main/scala/org/apache/livy/utils/LineBufferedStream.scala
@@ -23,8 +23,6 @@ import java.util.concurrent.locks.ReentrantLock
 
 import scala.io.Source
 
-import com.google.common.collect.EvictingQueue
-
 import org.apache.livy.Logging
 
 class CircularQueue[T](var capacity: Int) extends util.LinkedList[T] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

PR #181 removed guava dependency in LivyServer, but it still left unused guava import. Here in this minor fix, removed this unused import.

## How was this patch tested?

Existing UTs.

Author: jerryshao <jerryshao@tencent.com>

Closes #191 from jerryshao/remove-guava-minor.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
